### PR TITLE
Fix for Python >= 3.x (encoding parameter in json.dumps method)

### DIFF
--- a/a10_ansible/axapi_http.py
+++ b/a10_ansible/axapi_http.py
@@ -119,7 +119,11 @@ class HttpClient(object):
         payload = None
         if params and method != "GET":
             params_copy = params.copy()
-            payload = json.dumps(params_copy, encoding='utf-8')
+            # do not set encoding parameter if on python >= 3.x
+            if sys.version_info >= (3, 0):
+                payload = json.dumps(params_copy)
+            else:
+                payload = json.dumps(params_copy, encoding='utf-8')
 
         if file_name is not None:
             files = {


### PR DESCRIPTION
Do not set the parameter 'encoding' for json.dumps if on python >= 3.x (fixes #39).

Error (w/o the fix) on Python 3.x:

> `
> failed: [localhost] (item=master02vt.ocp4.example.com) => {"ansible_loop_var": "item", "changed": false, "item": "master02vt.ocp4.example.com", "module_stderr": "/root/.ansible/tmp/ansible-tmp-1577972742.69552-227097286102574/AnsiballZ_a10_slb_server.py:18: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses\n  import imp\nTraceback (most recent call last):\n  File \"/workspace/a10-ansible/a10_ansible/axapi_http.py\", line 304, in activate_partition\n    self.post(url, {\"active-partition\": payload})\n  File \"/workspace/a10-ansible/a10_ansible/axapi_http.py\", line 289, in post\n    return self._request('POST', url, params, **kwargs)\n  File \"/workspace/a10-ansible/a10_ansible/axapi_http.py\", line 273, in _request\n    self.session.get_auth_header(), **kwargs)\n  File \"/workspace/a10-ansible/a10_ansible/axapi_http.py\", line 226, in get_auth_header\n    \"Authorization\": \"A10 {0}\".format(self.id)\n  File \"/workspace/a10-ansible/a10_ansible/axapi_http.py\", line 221, in id\n    self.authenticate(self.username, self.password)\n  File \"/workspace/a10-ansible/a10_ansible/axapi_http.py\", line 241, in authenticate\n    r = self.http.post(url, payload)\n  File \"/workspace/a10-ansible/a10_ansible/axapi_http.py\", line 191, in post\n    return self.request(\"POST\", api_url, params, headers, **kwargs)\n  File \"/workspace/a10-ansible/a10_ansible/axapi_http.py\", line 122, in request\n    payload = json.dumps(params_copy, encoding='utf-8')\n  File \"/usr/lib/python3.7/json/__init__.py\", line 238, in dumps\n    **kw).encode(obj)\nTypeError: __init__() got an unexpected keyword argument 'encoding'\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"/root/.ansible/tmp/ansible-tmp-1577972742.69552-227097286102574/AnsiballZ_a10_slb_server.py\", line 114, in <module>\n    _ansiballz_main()\n  File \"/root/.ansible/tmp/ansible-tmp-1577972742.69552-227097286102574/AnsiballZ_a10_slb_server.py\", line 106, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/root/.ansible/tmp/ansible-tmp-1577972742.69552-227097286102574/AnsiballZ_a10_slb_server.py\", line 49, in invoke_module\n    imp.load_module('__main__', mod, module, MOD_DESC)\n  File \"/usr/lib/python3.7/imp.py\", line 234, in load_module\n    return load_source(name, filename, file)\n  File \"/usr/lib/python3.7/imp.py\", line 169, in load_source\n    module = _exec(spec, sys.modules[name])\n  File \"<frozen importlib._bootstrap>\", line 630, in _exec\n  File \"<frozen importlib._bootstrap_external>\", line 728, in exec_module\n  File \"<frozen importlib._bootstrap>\", line 219, in _call_with_frames_removed\n  File \"/tmp/ansible_a10_slb_server_payload_9z76uvl3/__main__.py\", line 709, in <module>\n  File \"/tmp/ansible_a10_slb_server_payload_9z76uvl3/__main__.py\", line 701, in main\n  File \"/tmp/ansible_a10_slb_server_payload_9z76uvl3/__main__.py\", line 678, in run_command\n  File \"/workspace/a10-ansible/a10_ansible/axapi_http.py\", line 306, in activate_partition\n    raise Exception(\"Could not activate due to: {0}\".format(ex)) \nException: Could not activate due to: __init__() got an unexpected keyword argument 'encoding'\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
> `