### PR TITLE
a10_file_aflex: fix import path for create/update

### DIFF
--- a/plugins/modules/a10_file_aflex.py
+++ b/plugins/modules/a10_file_aflex.py
@@ -249,6 +249,14 @@ def new_url(module):
 def report_changes(module, result, existing_config, payload):
     change_results = copy.deepcopy(result)
     if not existing_config:
+        change_results["changed"] = True
+        change_results["modified_values"].update(**payload)
+        return change_results
+
+    if module.params.get("action") == "import":
+        # /file/aflex/oper does not expose script contents, so import cannot
+        # safely determine content idempotency from existing_config metadata.
+        change_results["changed"] = True
         change_results["modified_values"].update(**payload)
         return change_results
 


### PR DESCRIPTION
Fixes incorrect behavior in a10_file_aflex when using `action=import`.

## Description
Severity Level: High  
Issue Description: There are two related issues in a10_file_aflex when using `action=import`.

This behavior has been validated against live ACOS devices.

### 1) Incorrect change detection for new aFleX uploads

The module relies on `/file/aflex/oper`, which does not return the
aFleX script contents. Change detection is therefore based only on
file name / file handle metadata.

This results in false idempotency:
- New aFleX scripts may be reported as unchanged even though creation/upload is required
- The module may report `changed=false` when a file should be created/uploaded

### 2) Existing aFleX scripts are not updated

When an aFleX script already exists:
- The module determines no change based on metadata comparison
- update() is never called
- post_file() is not executed
- The script is not updated even if contents differ

As a result, `action=import` does not reliably perform updates to
existing aFleX scripts.

## Technical Approach

This behavior is limited to `action=import`, which is treated as an explicit upload/update operation.

### Fix 1: Correct create-path change reporting

- When no existing aFleX is returned, ensure the module correctly treats the
  resource as absent and requiring creation.
- Report `changed=True` when the aFleX does not exist so the module
  correctly reflects that a create/upload operation is required.
- This fixes the create/import case where a new aFleX upload was not accurately
  reflected in module state/output.

### Fix 2: Enable updates for existing scripts

- For `action=import`, avoid relying on metadata-only comparison from
  `/file/aflex/oper` to determine whether upload is needed.
- Ensure the update path is taken for existing aFleX scripts when
  `action=import` is specified, so `post_file()` is invoked.
- This allows existing aFleX scripts to be replaced when `action=import` is used.

## General Playbook Changes

None.

## Test Cases

No automated unit tests were added.

Manually validated:
- Import new aFleX script (non-existent resource)
- Import existing aFleX script with modified content
- Re-import existing aFleX script to verify consistent behavior
- Verified behavior when existing_config is present and absent

## Manual Testing

1. Create a test aFleX script locally
2. Run playbook with:
   action: import

3. Verify:
   - Script is uploaded when not present
   - Script is updated when contents change

4. Confirm via device CLI:
   show aflex <name>

5. Re-run playbook to confirm no failures and consistent behavior
